### PR TITLE
NOTICK: populate now required `reporter` field

### DIFF
--- a/common/net/jira/action.js
+++ b/common/net/jira/action.js
@@ -10,14 +10,16 @@ class CreateJiraIssueAction {
         this.labels = labels;
         this.token = token;
       }
-    
+
       async execute() {
           let config = {
               headers: {
                   'Authorization': `Basic ${this.token}`,
               }
           }
-  
+
+          const myself = await axios.get(`${this.baseurl}/rest/api/2/myself`, config);
+
           let data = {
             "fields": {
                 "summary": this.summary,
@@ -28,10 +30,13 @@ class CreateJiraIssueAction {
                 "issuetype": {
                   "name": this.issuetype
                 },
-                "labels": this.labels
+                "labels": this.labels,
+                "reporter": {
+                    "id": myself.data.accountId
+                }
             }
           }
-  
+
           const response = await axios.post(`${this.baseurl}/rest/api/2/issue`, data, config);
           //console.log('Full response:\n');
           //console.log(response)


### PR DESCRIPTION
* JIRA configuration has changed and `reporter` field is required during
  creation of a new JIRA ticket
* autosense the account id of the credentials configured for Github
  Actions
* use `accountId` instead of account name, because for some reason
  account names are not resolved at all. Possibly a side effect of SSO
  configuration for Jira Cloud.