### PR TITLE
NOTICK: updated Node to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ outputs:
   issue:
     description: Key of the newly created issue
 runs:
-  using: 'node12'
+  using: 'node16'
   main: './index.js'


### PR DESCRIPTION
Github started to deprecate NodeJS 12 actions and move them to Node16 environment, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ more details